### PR TITLE
Fix for Python 3.11+ and test on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          python -m tox -e py
+
+      - name: Test CLI
+        run: |
+          python -m tox -e cli

--- a/oblique/__init__.py
+++ b/oblique/__init__.py
@@ -13,36 +13,51 @@ import click
 CURRENT_DIR = Path(__file__).parent
 
 
+DEFAULT_EDITION = "1,2,3,4"
+DEFAULT_COUNT = 3
+DEFAULT_EXTRA = False
+DEFAULT_PYTHON = False
+
+
 @click.command()
 @click.version_option(__version__)
 @click.option(
     "--edition",
-    default="1,2,3,4",
+    default=DEFAULT_EDITION,
     help="Which OS editions to include?",
     show_default=True,
 )
 @click.option(
     "--extra",
     is_flag=True,
-    default=False,
+    default=DEFAULT_EXTRA,
     help="Include additional koans found online",
     show_default=True,
 )
 @click.option(
     "--python",
     is_flag=True,
-    default=False,
+    default=DEFAULT_PYTHON,
     help="Include Monty Python quotes",
     show_default=True,
 )
 @click.option(
     "--count",
-    default=3,
+    default=DEFAULT_COUNT,
     type=int,
     help="How many koans to show",
     show_default=True,
 )
-def main(edition: str, count: int, extra: bool, python: bool) -> None:
+def main_command(edition: str, count: int, extra: bool, python: bool) -> None:
+    return main(edition, count, extra, python)
+
+
+def main(
+    edition: str = DEFAULT_EDITION,
+    count: int = DEFAULT_COUNT,
+    extra: bool = DEFAULT_EXTRA,
+    python: bool = DEFAULT_PYTHON,
+) -> None:
     include_editions: set[int] = set()
     for value in edition.split(","):
         if not value:

--- a/oblique/__init__.py
+++ b/oblique/__init__.py
@@ -71,7 +71,7 @@ def main(
     strategies = get_strategies(include_editions, python=python, extra=extra)
 
     try:
-        for koan in random.sample(strategies, count):
+        for koan in random.sample(list(strategies), count):
             print(koan)
     except ValueError as ve:
         print(

--- a/tests/test_oblique.py
+++ b/tests/test_oblique.py
@@ -1,4 +1,4 @@
-from oblique import get_strategies
+from oblique import get_strategies, main
 
 
 def test_all():
@@ -12,3 +12,7 @@ def test_all():
 def test_zero():
     s = get_strategies(editions=set(), extra=False, python=False)
     assert len(s) == 0
+
+
+def test_main():
+    main(edition="1,2,3,4", count=3, extra=False, python=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+requires =
+    tox>=4.2
+env_list =
+    cli
+    py{py3, 313, 312, 311, 310, 39, 38, 37}
+
+[testenv]
+deps =
+    pytest
+pass_env =
+    FORCE_COLOR
+commands =
+    {envpython} -m pytest {posargs}
+
+[testenv:cli]
+commands =
+    oblique --version
+    oblique --help
+    oblique


### PR DESCRIPTION
With Python 3.11+:

```pytb
❯ python3.11 -m oblique
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/private/tmp/oblique/oblique/__main__.py", line 4, in <module>
    main()
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/oblique/oblique/__init__.py", line 59, in main
    for koan in random.sample(strategies, count):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/random.py", line 439, in sample
    raise TypeError("Population must be a sequence.  "
TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
```

Because:

> Changed in version 3.11: The population must be a sequence. Automatic conversion of sets to lists is no longer supported.

https://docs.python.org/3/library/random.html#random.sample

So let's convert `strategies` to a list before passing to `random.sample`.

* CI before fix: https://github.com/hugovk/oblique/actions/runs/9515526981
* CI after fix: https://github.com/hugovk/oblique/actions/runs/9515659446
